### PR TITLE
Kari better argument parsing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,8 +18,7 @@
                 "-generatedName", "Generated",
                 "-rootNamespace", "SomeProject",
                 "-commonNamespace", "Common",
-                "-clearOutput", "true",
-                "-monolithicProject", "false"
+                "-clearOutput",
             ],
             "cwd": "${workspaceFolder}",
             "console": "externalTerminal",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -16,7 +16,7 @@
             "label": "build_kari_debug",
             "command": "baton",
             "args": [
-                "kari", "build", "-debug", "-plugin", "DataObject", "-no_generator"
+                "kari", "build", "-debug", "-no_plugins"//, "-plugin", "DataObject", "-no_generator"
             ]
         },
         {

--- a/Kari/Kari.Generator/Kari.Generator.csproj
+++ b/Kari/Kari.Generator/Kari.Generator.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>8</LangVersion>
-    <Nullable>enable</Nullable>
+    <!-- <Nullable>enable</Nullable> -->
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>kari</ToolCommandName>

--- a/Kari/Kari.Generator/KariCompiler.cs
+++ b/Kari/Kari.Generator/KariCompiler.cs
@@ -57,7 +57,7 @@
 
             var compiler = new KariCompiler();
 
-            if (parser.Options.Count == 0)
+            if (parser.IsEmpty)
             {
                 System.Console.WriteLine(parser.GetHelpFor(compiler));
                 return 0;
@@ -67,7 +67,7 @@
             {
                 System.Environment.ExitCode = await compiler.RunAsync(parser, token);
             }
-            catch (OperationCanceledException e)
+            catch (OperationCanceledException)
             {
                 return (int) ExitCode.OperationCanceled;
             }

--- a/Kari/Kari.Generator/PseudoCompilation.cs
+++ b/Kari/Kari.Generator/PseudoCompilation.cs
@@ -95,9 +95,9 @@ namespace Kari.Generator
             return metadata;
         }
 
-        private static IEnumerable<string>? CleanPreprocessorSymbols(IEnumerable<string>? preprocessorSymbols)
+        private static IEnumerable<string> CleanPreprocessorSymbols(IEnumerable<string> preprocessorSymbols)
         {
-            return preprocessorSymbols?.Where(x => !string.IsNullOrWhiteSpace(x));
+            return preprocessorSymbols.Where(x => !string.IsNullOrWhiteSpace(x));
         }
 
         private static IEnumerable<string> IterateCsFileWithoutBinObjIgnoringFolder(string root, string ingoredFolderName)

--- a/Kari/Kari.GeneratorCore/Utils/ArgumentParsing.cs
+++ b/Kari/Kari.GeneratorCore/Utils/ArgumentParsing.cs
@@ -127,7 +127,7 @@ namespace Kari.GeneratorCore
         /// Fills in the given object fields via reflection with the parsed options.
         /// Fields take their value from the option with exactly the same name as that field.
         /// Shortened options like `-i` are not supported.
-        /// Only field types supported: string, int, bool, string[], List<string>, int[] 
+        /// Only field types supported: string, int, bool, string[], List<string>, int[], HashSet<string>
         /// </summary>
         public MappingResult FillObjectWithOptionValues(object t)
         {
@@ -159,7 +159,8 @@ namespace Kari.GeneratorCore
                     || fieldInfo.FieldType == typeof(string) 
                     || fieldInfo.FieldType == typeof(string[]) 
                     || fieldInfo.FieldType == typeof(List<string>) 
-                    || fieldInfo.FieldType == typeof(int[]));
+                    || fieldInfo.FieldType == typeof(int[])
+                    || fieldInfo.FieldType == typeof(HashSet<string>));
 
                 bool Validate()
                 {
@@ -258,6 +259,10 @@ namespace Kari.GeneratorCore
                 {
                     SetValue(ParseAsStringArray().ToList());
                 }
+                else if (fieldInfo.FieldType == typeof(HashSet<string>))
+                {
+                    SetValue(ParseAsStringArray().ToHashSet());
+                }
                 else if (fieldInfo.FieldType == typeof(int[]))
                 {
                     var arr = ParseAsStringArray();
@@ -328,6 +333,14 @@ namespace Kari.GeneratorCore
                             {
                                 var b = new StringBuilder(" = [");
                                 b.Append(String.Join(",", arr));
+                                b.Append("]");
+
+                                toAppend = b.ToString();
+                            }
+                            else if (value is HashSet<string> set)
+                            {
+                                var b = new StringBuilder(" = [");
+                                b.Append(String.Join(",", set));
                                 b.Append("]");
 
                                 toAppend = b.ToString();

--- a/Kari/Kari.GeneratorCore/Utils/ArgumentParsing.cs
+++ b/Kari/Kari.GeneratorCore/Utils/ArgumentParsing.cs
@@ -1,0 +1,355 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace Kari.GeneratorCore
+{
+    public class OptionAttribute : System.Attribute
+    {
+        public string Help;
+        public bool IsFlag { get; set; }
+        public bool IsRequired { get; set; }
+
+        public OptionAttribute(string help)
+        {
+            Help = help;
+        }
+    }
+
+    public class ArgumentParser
+    {
+        public class ArgumentOrOptionValue
+        {
+            public readonly string StringValue;
+            // Indicates whether this value has been recognized as a valid option.
+            public bool IsMarked { get; set; }
+            public ArgumentOrOptionValue(string stringValue) => StringValue = stringValue;
+        }
+
+        public readonly Dictionary<string, ArgumentOrOptionValue> Options = new Dictionary<string, ArgumentOrOptionValue>();
+
+        public struct ParsingResult
+        {
+            public readonly string Error;
+            public bool IsError => !(Error is null);
+            public ParsingResult(string error) => Error = error;
+
+            public static readonly ParsingResult Ok = new ParsingResult(null);
+            public static ParsingResult DoubleDash(string argument) 
+                => new ParsingResult($"Double dash is not allowed (in `{argument}`). Use single dash instead.");
+            public static ParsingResult InvalidOptionFormat(string argument) 
+                => new ParsingResult($"The option `{argument}` must start with a single dash `-`.");
+
+            public static ParsingResult DuplicateOption(string option)
+                => new ParsingResult($"Duplicate option `{option}`.");
+        }
+
+        public ParsingResult ParseArguments(string[] arguments)
+        {
+            int i = 0;
+
+            // I decided I don't want to allow posiitonal arguments
+            // Process positional arguments first
+            // for (;i < arguments.Length; i++)
+            // {
+            //     if (arguments[i][0] == '-')
+            //         break;
+                
+            //     PositionalArguments.Add(new ArgumentOrOptionValue(arguments[i]));
+            // }
+
+            while (i < arguments.Length)
+            {
+                // This is an option
+                if (arguments[i][0] != '-')
+                {
+                    return ParsingResult.InvalidOptionFormat(arguments[i]);
+                }
+
+                // We do not allow "--"
+                if (arguments[i][1] == '-')
+                {
+                    return ParsingResult.DoubleDash(arguments[i]);
+                }
+
+                string option = arguments[i].Substring(1);
+
+                if (Options.ContainsKey(option))
+                {
+                    return ParsingResult.DuplicateOption(option);
+                }
+                
+                // If it's not followed by a value, or the value is an option,
+                // set the result to null.
+                i++;
+                if (i == arguments.Length || arguments[i][0] == '-')
+                {
+                    Options.Add(option, new ArgumentOrOptionValue(null));
+                    continue;
+                }
+
+                Options.Add(option, new ArgumentOrOptionValue(arguments[i]));
+                i++;
+            }
+
+            return ParsingResult.Ok;
+        }
+
+        public struct MappingResult
+        {
+            public readonly List<string> Errors;
+            public bool IsError => Errors.Count > 0;
+            private readonly object Result;
+
+            public MappingResult(object t)
+            {
+                Errors = new List<string>();
+                Result = t;
+            }
+        }
+
+        // public static class MappingResult
+        // {
+        //     public static MappingResult<T> Ok<T>(T result) => new MappingResult<T>(null, result);
+        //     public static MappingResult<T> Error<T>(string error) 
+        //         => new MappingResult<T>(error);
+        // }
+
+        /// Only field types supported: string, int, bool, string[], List<string>, int[] 
+        public MappingResult FillObjectWithOptionValues(object t)
+        {
+            // We must box the struct in order to set values for the fields.
+            MappingResult result = new MappingResult(t);
+
+            var type = t.GetType();
+            var memberInfos = type.GetFields(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
+
+            foreach (var fieldInfo in memberInfos)
+            foreach (var attr in fieldInfo.GetCustomAttributes(inherit: false))
+            {
+                if (!(attr is OptionAttribute optionAttribute))
+                {
+                    continue;
+                }
+
+                var name = fieldInfo.Name;
+                bool hasOption = Options.TryGetValue(name, out var option);
+                
+                void SetValue(object value)
+                {
+                    fieldInfo.SetValue(t, value);
+                }
+
+                Debug.Assert(!optionAttribute.IsRequired || !optionAttribute.IsFlag,
+                    $"{name} in type {type.FullName} cannot be both flag and required");
+
+                // Make sure it's one of the supported types.
+                Debug.Assert(fieldInfo.FieldType == typeof(bool) ||
+                    fieldInfo.FieldType == typeof(int) ||
+                    fieldInfo.FieldType == typeof(string) ||
+                    fieldInfo.FieldType == typeof(string[]) ||
+                    fieldInfo.FieldType == typeof(List<string>) ||
+                    fieldInfo.FieldType == typeof(int[]));
+
+                if (optionAttribute.IsRequired && !hasOption)
+                {
+                    result.Errors.Add($"Missing required option: {name}");
+                    break;
+                }
+                else if (!optionAttribute.IsFlag && hasOption && option.StringValue is null)
+                {
+                    result.Errors.Add($"Option {name} cannot be used like a flag");
+                    break;
+                }
+                else if (optionAttribute.IsFlag)
+                {
+                    Debug.Assert(fieldInfo.FieldType == typeof(bool),
+                        $"{name}, indicated as flag, must be bool type");
+
+                    Debug.Assert(((bool) fieldInfo.GetValue(t)) == false,
+                        "The default value for {name} flag must be true");
+
+                    if (hasOption)
+                    {
+                        option.IsMarked = true;
+                        if (option.StringValue is null)
+                        {
+                            SetValue(true);
+                        }
+                        else
+                        {
+                            result.Errors.Add($"Option {name} is a flag, you cannot pass it a value");
+                        }
+                    }
+                    // If it's not set it's already false
+                    break;
+                }
+                else if (!hasOption)
+                {
+                    break;
+                }
+
+                void AddErrorUnknownValue()
+                {
+                    result.Errors.Add($"Unknown value for {name} of type {fieldInfo.FieldType.FullName}: {option.StringValue}.");
+                }
+
+                int ParseAsInteger(string str)
+                {
+                    if (int.TryParse(str, out int value))
+                    {
+                        return value;
+                    }
+                    AddErrorUnknownValue();
+                    return 0;
+                }
+
+                string[] ParseAsStringArray()
+                {
+                    var str = option.StringValue;
+                    return str.Split(',');
+                }
+
+                option.IsMarked = true;
+                if (fieldInfo.FieldType == typeof(bool))
+                {
+                    var comparer = StringComparer.OrdinalIgnoreCase;
+                    if (comparer.Equals(option.StringValue, "TRUE"))
+                    {
+                        SetValue(true);
+                    }
+                    else if (comparer.Equals(option.StringValue, "FALSE"))
+                    {
+                        SetValue(false);
+                    }
+                    else
+                    {
+                        AddErrorUnknownValue();
+                    }
+                }
+                else if (fieldInfo.FieldType == typeof(int))
+                {
+                    SetValue(ParseAsInteger(option.StringValue));
+                }
+                else if (fieldInfo.FieldType == typeof(string))
+                {
+                    SetValue(option.StringValue);
+                }
+                else if (fieldInfo.FieldType == typeof(string[]))
+                {
+                    SetValue(ParseAsStringArray());
+                }
+                else if (fieldInfo.FieldType == typeof(List<string>))
+                {
+                    SetValue(ParseAsStringArray().ToList());
+                }
+                else if (fieldInfo.FieldType == typeof(int[]))
+                {
+                    var arr = ParseAsStringArray();
+                    var ints = new int[arr.Length];
+                    for (int i = 0; i < arr.Length; i++)
+                    {
+                        ints[i] = ParseAsInteger(arr[i]);
+                    }
+                    SetValue(ints);
+                }
+            }
+
+            return result;
+        }
+    
+        private static readonly string[] _Header = new string[] { "Option", "Type", "Description" };  
+        public string GetHelpFor(object t)
+        {
+            var type = t.GetType();
+            var sb = new EvenTableBuilder(_Header);
+
+            foreach (var fieldInfo in type.GetFields(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance))
+            foreach (var attr in fieldInfo.GetCustomAttributes(inherit: false))
+            {
+                if (!(attr is OptionAttribute optionAttribute))
+                    continue;
+                
+                Debug.Assert(!string.IsNullOrEmpty(optionAttribute.Help));
+
+                // Split the help in manageable pieces that all could sort of wrap in the third column,
+                // but we're emulating wrapping by appending spaces.
+                const int chunkLength = 64;
+                for (int i = 0; i < optionAttribute.Help.Length; i += chunkLength)
+                {
+                    if (i == 0)
+                    {
+                        sb.Append(column: 0, fieldInfo.Name);
+                        
+                        string typeName = fieldInfo.FieldType.Name;
+                        string toAppend;
+                        if (optionAttribute.IsRequired)
+                        {
+                            toAppend = " (required)";
+                        }
+                        else if (optionAttribute.IsFlag)
+                        {
+                            toAppend = " (flag)";
+                        }
+                        else
+                        {
+                            var value = fieldInfo.GetValue(t);
+
+                            if (value is null)
+                            {
+                                toAppend = "";
+                            }
+                            else if (value is string[] arr)
+                            {
+                                var b = new StringBuilder(" = [");
+                                b.Append(String.Join(",", arr));
+                                b.Append("]");
+
+                                toAppend = b.ToString();
+                            }
+                            else if (value is int[] intArr)
+                            {
+                                var b = new StringBuilder(" = [");
+                                b.Append(String.Join(",", intArr));
+                                b.Append("]");
+
+                                toAppend = b.ToString();
+                            }
+                            else
+                            {
+                                toAppend = $" = {value}";
+                            }
+                        }
+
+                        sb.Append(column: 1, typeName + toAppend);
+                    }
+                    else
+                    {
+                        // Just skip these columns
+                        sb.Append(column: 0, "");
+                        sb.Append(column: 1, "");
+                    }
+                    sb.Append(column: 2, optionAttribute.Help.Substring(i, 
+                        // It may not go beyond the end
+                        Math.Min(chunkLength, optionAttribute.Help.Length - i)));
+                }
+            }
+
+            return sb.ToString();
+        }
+    
+        public IEnumerable<string> GetUnrecognizedOptions()
+        {
+            foreach (var option in Options)
+            {
+                if (!option.Value.IsMarked)
+                {
+                    yield return option.Key;
+                }
+            } 
+        }
+    }
+}

--- a/Kari/Kari.GeneratorCore/Workflow/Administrator.cs
+++ b/Kari/Kari.GeneratorCore/Workflow/Administrator.cs
@@ -12,6 +12,13 @@ namespace Kari.GeneratorCore.Workflow
         string GetAnnotations();
 
         /// <summary>
+        /// Returns the object to take arguments from the command line.
+        /// It is called before initialization.
+        /// You should do validation of received values in the `Initialize()` method.
+        /// </summary>
+        object GetArgumentObject() => this;
+
+        /// <summary>
         /// Method called after a reference to MasterEnvironment has been set.
         /// The MasterEnvironment already contains the projects at this point.
         /// </summary>

--- a/Kari/Kari.GeneratorCore/Workflow/CodeFileWriter.cs
+++ b/Kari/Kari.GeneratorCore/Workflow/CodeFileWriter.cs
@@ -83,7 +83,7 @@ namespace Kari.GeneratorCore.Workflow
     public class OneFilePerProjectFileWriter : IFileWriter, IDisposable
     {
         private readonly string _filePath;
-        private StreamWriter? _file;
+        private StreamWriter _file;
 
         public OneFilePerProjectFileWriter(string generatedFilePath)
         {

--- a/Kari/Kari.GeneratorCore/Workflow/Logger.cs
+++ b/Kari/Kari.GeneratorCore/Workflow/Logger.cs
@@ -99,12 +99,17 @@ namespace Kari.GeneratorCore.Workflow
             LogNoLock(message, LogType.Error);
         }
 
-
         public void LogNoLock(string message, LogType type = LogType.Message)
         {
             Console.ForegroundColor = (ConsoleColor) type;
             Console.WriteLine($"[{_name}]: {message}");
             _HasErrors = _HasErrors || (type == LogType.Error);
+        }
+
+        public static void LogPlain(string message)
+        {
+            Console.ForegroundColor = (ConsoleColor) LogType.Message;
+            Console.WriteLine(message);
         }
 
         public void LogError(string message)

--- a/Kari/Kari.GeneratorCore/Workflow/MasterEnvironment.cs
+++ b/Kari/Kari.GeneratorCore/Workflow/MasterEnvironment.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -12,6 +13,9 @@ namespace Kari.GeneratorCore.Workflow
 {
     public class MasterEnvironment : Singleton<MasterEnvironment>
     {
+        // TODO: 
+        // We could use [Option] here and fill these in directly, but then we will also 
+        // have to bring the validation logic here. Do I want that?
         public string CommonProjectName { get; set; } = "Common"; 
         public string GeneratedPath { get; set; } = "Generated";
         public string GeneratedNamespaceSuffix { get; set; } = "Generated";
@@ -48,10 +52,22 @@ namespace Kari.GeneratorCore.Workflow
             foreach (var admin in Administrators)
             {
                 var result = parser.FillObjectWithOptionValues(admin.GetArgumentObject());
-                foreach (var err in result.Errors)
+                if (result.IsError)
                 {
-                    Logger.LogError(err);
+                    foreach (var err in result.Errors)
+                    {
+                        Logger.LogError(err);
+                    }
                 }
+            }
+        }
+
+        public void LogHelpForEachAdministrator(ArgumentParser parser)
+        {
+            foreach (var admin in Administrators)
+            {
+                Logger.LogPlain($"\nShowing help for `{admin}`.");
+                Logger.LogPlain(parser.GetHelpFor(admin.GetArgumentObject()));
             }
         }
 
@@ -64,8 +80,7 @@ namespace Kari.GeneratorCore.Workflow
             Compilation = Compilation;
             RootNamespace = Compilation.TryGetNamespace(RootNamespaceName);
 
-            // TODO: log instead?
-            if (RootNamespace is null) Logger.LogError($"No such namespace {RootNamespaceName}");
+            if (RootNamespace is null)  Logger.LogError($"No such namespace {RootNamespaceName}");
         }
 
         private void AddProject(ProjectEnvironment project)

--- a/Kari/Kari.GeneratorCore/Workflow/MasterEnvironment.cs
+++ b/Kari/Kari.GeneratorCore/Workflow/MasterEnvironment.cs
@@ -43,6 +43,18 @@ namespace Kari.GeneratorCore.Workflow
             IndependentNamespaces = independentNamespaces;
         }
 
+        public void TakeCommandLineArguments(ArgumentParser parser)
+        {
+            foreach (var admin in Administrators)
+            {
+                var result = parser.FillObjectWithOptionValues(admin.GetArgumentObject());
+                foreach (var err in result.Errors)
+                {
+                    Logger.LogError(err);
+                }
+            }
+        }
+
         public void InitializeCompilation(ref Compilation compilation)
         {
             Compilation = compilation.AddSyntaxTrees(

--- a/Kari/Kari.Plugins/Terminal/TerminalAdministrator.cs
+++ b/Kari/Kari.Plugins/Terminal/TerminalAdministrator.cs
@@ -5,6 +5,9 @@ namespace Kari.Plugins.Terminal
 {
     public class TerminalAdministrator : IAdministrator
     {
+        [Kari.GeneratorCore.Option("Namespace of the Terminal project.")]
+        string terminalProject = "Terminal";
+
         public ParsersAnalyzer[] _parserAnalyzers;
         public CommandsAnalyzer[] _commandAnalyzers;
         public static ProjectEnvironmentData TerminalProject { get; private set; }
@@ -12,13 +15,16 @@ namespace Kari.Plugins.Terminal
 
         public void Initialize()
         {
-            // For now, let's just say we output to the project with "Terminal" in its name
-            TerminalProject = MasterEnvironment.Instance.Projects.Find(
-                project => project.RootNamespace.Name.Contains("Terminal"));
-            // We default to the root project otherwise
-            TerminalProject ??= MasterEnvironment.Instance.RootPseudoProject;
-
             _logger = new Logger("TerminalPlugin");
+
+            TerminalProject = MasterEnvironment.Instance.Projects.Find(
+                project => project.RootNamespace.Name == terminalProject);
+            
+            if (TerminalProject is null)
+            {
+                _logger.LogError($"Terminal project `{terminalProject}` could not be found");
+                return;
+            }
 
             ParserSymbols.Initialize(_logger);
             CommandSymbols.Initialize(_logger);

--- a/Kari/Kari.Plugins/UnityHelpers/UnityHelpersAdministrator.cs
+++ b/Kari/Kari.Plugins/UnityHelpers/UnityHelpersAdministrator.cs
@@ -6,18 +6,22 @@ namespace Kari.Plugins.UnityHelpers
 {
     /// <summary>
     /// This is a analyzer-less plugin, that is, it generates the same output independent of the input project.
-    /// TODO: Get EngineCommon project name parameter as an argument.
-    /// TODO: Make a special analyzer-less type of administrators??
     /// </summary>
     public class UnityHelpersAdministrator : IAdministrator
     {
+        [Option("The namespace of the engine-dependent common project")]
+        string engineCommon = "EngineCommon";
+
         public ProjectEnvironmentData _engineCommon;
+        private Logger _logger = new Logger("UnityHelpers admin");
+
         public void Initialize() 
         {
-            _engineCommon = MasterEnvironment.Instance.Projects.Find(
-                p => p.NamespaceName == "EngineCommon");
-            _engineCommon ??= MasterEnvironment.Instance.RootPseudoProject;
+            _engineCommon = MasterEnvironment.Instance.Projects.Find(p => p.NamespaceName == engineCommon);
+            if (_engineCommon is null) 
+                _logger.LogError($"The engine common project `{engineCommon}` could not be found");
         }
+        
         public string GetAnnotations() => "";
         public Task Collect() => Task.CompletedTask;
         public Task Generate()

--- a/Kari/README.md
+++ b/Kari/README.md
@@ -77,6 +77,13 @@ if (symbol.TryGetAttribute(Symbols.MyAttribute, logger, out MyAttribute attribut
 Currently, it does not support arrays other than string arrays, but I have not yet had a use case for that.
 
 
+### Getting command line options
+
+You can mark any fields in your administrator with `[Option]` to associate options passed via command line with exactly the same name to them.
+You can make them required, by setting `IsRequired` to true in the constructor.
+See the file `ArgumentParsing.cs` for an API overview, and override `IAdministrator.GetArgumentObject()` if you want to define the options somewhere else than directly in the administrator class.
+
+
 ## Default plugins
 
 None of the plugins are included by default by `Kari`, however, there are some useful ones already defined in this repo.
@@ -94,3 +101,7 @@ Generates backend code for terminal commands. See a complete example repo [here]
 Generates boilerplate helper functions related to unity. Currently, makes helper functions for changing individual coordinates of `Vector`'s.
 
 The idea comes from [here](https://github.com/TobiasWehrum/unity-utilities/blob/c78da2928b1f7b73046a697185271e7effeddd1f/UnityHelper/UnityHelper.cs#L199), but results in no runtime penalty of checking nullable types.
+
+### DataObject
+
+Automatically defines `==`, `!=`, `Equals()` and some others for conceptually data-only objects. 

--- a/Kari/README.md
+++ b/Kari/README.md
@@ -2,7 +2,7 @@
 
 ## How to use?
 
-Kari is designed for use in this particular project, and is has not been tested anywhere else (yet).
+Kari is designed for use in this particular project, and has not been tested anywhere else (yet).
 
 You can call `baton kari unity` to run the code generator on the subproject, but the code generator can be used directly, without `baton`.
 You can use e.g. `dotnet run -p Kari.Generator/Kari.Generator.csproj` to compile and run Kari.

--- a/python_cli/baton/baton.py
+++ b/python_cli/baton/baton.py
@@ -324,15 +324,10 @@ def generate_code_for_unity():
             "-generatedName", "Generated",
             "-rootNamespace", "SomeProject",
             "-commonNamespace", "Common",
-            "-clearOutput", "true",
-            "-monolithicProject", "false"]
-        # [   "-input", f"{PROJECT_DIRECTORY}/Kari/Kari.Test", 
-        #     "-pluginsLocations", f"{MSBUILD_OUTPUT_PATH}/Terminal/Release/netcoreapp3.1/publish/Kari.Plugins.Terminal.dll,{MSBUILD_OUTPUT_PATH}/Flags/Release/netcoreapp3.1/publish/Kari.Plugins.Flags.dll",
-        #     "-generatedName", "Generated",
-        #     "-rootNamespace", "Kari",
-        #     "-clearOutput", "true",
-        #     "-monolithicProject", "true"]
-        )
+            "-clearOutput",
+            "-terminalProject", "CommandTerminal",
+            "-engineCommon", "EngineCommon"
+        ])
 
 
 @kari.command("nuke")

--- a/python_cli/baton/baton.py
+++ b/python_cli/baton/baton.py
@@ -234,8 +234,9 @@ def build_kari(clean=False, retry=False, debug=False, plugin : 'list[str]' = Non
         for cmd in cmds:
             execute(cmd)
         
-        log_success(f"The final dll has been written to {KARI_GENERATOR_PATH}")
-        log_success("To run it, do `baton kari run`, passing in the flags`")
+        log_success(f"Path to Kari: {KARI_GENERATOR_PATH}")
+        log_success("To run it, do `baton kari run`, passing in the flags")
+
         # TODO: actually run tests
         # run_sync("dotnet run -p Kari.Test")
 


### PR DESCRIPTION
**Summary:**
Implemented a better argument parsing strategy.
- No dependency on lousy libraries, which lack features I want, and add features I don't want.
- A very simple argument parser class, which uses reflection to find fields with `Option` attribute, then parses the option according to the type.
- Added the concept of requirability of options, and flag options.
- Added help message generation.
- Detect unrecognized options and error out if any were found. The library I was using *did not have that* (or it was opt-in and very well hidden), how crazy is that.
- Now, all administrators are filled in with provided arguments by annotating fields with the `Option` attribute, just like the main class. The program errors out (currently), if any errors are detected (it should display the help of the administrator from which the error came).
- Typing the command without any arguments currently shows the help message (but just for the command, not the plugins, since there is no option to tell you their path). I will add a `help` option, just to breach this gap.
- The options are of the form `-identifier`. Double dash and short options like `-i` are stupid in my opinion so they are not allowed.
- Only allowed types are `int`, `bool`, `string`, `string[]`, `List<string>` and `int[]`. I may add `HashSet<string>` and maybe a `Path` wrapper type in the future.
